### PR TITLE
Modernize Android SDK

### DIFF
--- a/beagle/android/build.gradle
+++ b/beagle/android/build.gradle
@@ -18,14 +18,15 @@ group 'br.com.zup.beagle.beagle'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.5.21'
+    ext.kotlin_version = '1.8.22'
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -34,6 +35,7 @@ rootProject.allprojects {
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
 }
 
@@ -42,6 +44,8 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 30
+  
+    namespace 'br.com.zup.beagle.beagle'
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -55,5 +59,5 @@ android {
 }
 
 dependencies {
-    implementation "com.github.fast-development.android-js-runtimes:fastdev-jsruntimes-jsc:0.1.9"
+    implementation 'com.github.fast-development.android-js-runtimes:fastdev-jsruntimes-jsc:0.1.9'
 }

--- a/beagle/android/gradle.properties
+++ b/beagle/android/gradle.properties
@@ -17,4 +17,3 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
-android.enableR8=true

--- a/beagle/android/gradle/wrapper/gradle-wrapper.properties
+++ b/beagle/android/gradle/wrapper/gradle-wrapper.properties
@@ -18,4 +18,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip

--- a/beagle/android/src/main/AndroidManifest.xml
+++ b/beagle/android/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
   -->
 
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="br.com.zup.beagle.beagle">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <queries>
         <intent>
             <action android:name="android.intent.action.VIEW" />

--- a/beagle_components/lib/src/dynamic_list/flexible_list_view.dart
+++ b/beagle_components/lib/src/dynamic_list/flexible_list_view.dart
@@ -85,7 +85,9 @@ class _FlexibleListView extends State<FlexibleListView> with AfterLayoutMixin {
     if (widget.useScrollbar) {
       list = Scrollbar(
         child: list,
-        isAlwaysShown: true,
+        // removed from sdk, see https://api.flutter.dev/flutter/material/Scrollbar/isAlwaysShown.html
+        // isAlwaysShown: true,
+        thumbVisibility: true,
         controller: widget.controller,
       );
     }

--- a/beagle_components/lib/src/internal/beagle_refresh_indicator.dart
+++ b/beagle_components/lib/src/internal/beagle_refresh_indicator.dart
@@ -306,7 +306,9 @@ class BeagleRefreshIndicatorState extends State<BeagleRefreshIndicator>
   bool _handleGlowNotification(OverscrollIndicatorNotification notification) {
     if (notification.depth != 0 || !notification.leading) return false;
     if (_mode == _RefreshIndicatorMode.drag) {
-      notification.disallowGlow();
+      // removed from sdk, see https://api.flutter.dev/flutter/widgets/OverscrollIndicatorNotification/disallowGlow.html
+      //notification.disallowGlow();
+      notification.disallowIndicator();
       return true;
     }
     return false;

--- a/sample/android/app/build.gradle
+++ b/sample/android/app/build.gradle
@@ -43,8 +43,10 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     ndkVersion "21.3.6528147"
-    compileSdkVersion 31
+    compileSdkVersion 33
 
+   namespace 'br.com.zup.beagle.beagle'
+  
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }

--- a/sample/android/build.gradle
+++ b/sample/android/build.gradle
@@ -15,14 +15,14 @@
  */
 
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.8.22'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:4.2.1"
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -31,6 +31,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
 }
 
@@ -42,6 +43,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/sample/android/gradle.properties
+++ b/sample/android/gradle.properties
@@ -15,6 +15,5 @@
 #
 
 org.gradle.jvmargs=-Xmx1536M
-android.enableR8=true
 android.useAndroidX=true
 android.enableJetifier=true

--- a/sample/android/gradle/wrapper/gradle-wrapper.properties
+++ b/sample/android/gradle/wrapper/gradle-wrapper.properties
@@ -19,4 +19,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip


### PR DESCRIPTION
### Description and Example

1. Fix some fields that were removed in the latest flutter sdk.
1. Upgrade gradle, kotlin and android gradle plugin.
1. Migrate android build to use namespace property to add AGP 8 compatibility. See https://developer.android.com/build/releases/gradle-plugin#namespace-dsl
